### PR TITLE
Update generate_nor.c

### DIFF
--- a/generate_nor.c
+++ b/generate_nor.c
@@ -80,7 +80,7 @@ typedef struct SyscfgHeader {
 } SyscfgHeader;
 
 typedef struct SyscfgEntry {
-        u_int32_t       seTag;
+        uint32_t       seTag;
         char        seData[16];
 } SyscfgEntry;
 


### PR DESCRIPTION
fix a typo where uint32_t = u_int32_t causing compilation errors